### PR TITLE
fix: Added information on how to install Python 3

### DIFF
--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -10,6 +10,7 @@ Set up your development environment
 ===================================
 
 Open a command prompt on your computer and make sure that you can successfully run the :code:`python3` command. Create a working directory for your code and change to it.
+If Python 3 is *not* installed, you can do so via `the official installer <https://www.python.org/downloads/>`_, or via `pyenv <https://github.com/pyenv/pyenv#simple-python-version-management-pyenv/>`_, as described in the `environment page <https://pybee.org/contributing/how/first-time/setup/>`_.
 
 The recommended way of setting up your development environment for Toga
 is to install a virtual environment, install the required dependencies and


### PR DESCRIPTION
Adds documentation for installing python 3.

The current documentation says to make sure `python3` can be successfully run, but does not say anything on what to do if it does not work.

This should improve the the issue #335

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
